### PR TITLE
Update collector.go

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	baseFile = "/tmp/lshttpd/.rtreport"
+	baseFile = "/dev/shm/lsws/status/.rtreport"
 )
 
 // LitespeedCollectorOpts carries the options used in LitespeedCollector


### PR DESCRIPTION
Collector can't access .rtreport when systemd PrivateTmp is enabled.

On systems where systemd's PrivateTmp is enabled for the lshttpd service, /tmp/lshttpd/.rtreport is inside the service's private temp namespace and not accessible from the host or from other processes. The collector currently uses /tmp/lshttpd/.rtreport as its base file and therefore can’t read the real status file.

Example observed on a host:
```bash
# ls -al /tmp/systemd-private-da6f7cfc1d2f4e26b9b439c2ae559f72-lshttpd.service-JKyVjn/tmp/lshttpd/.rtreport
lrwxrwxrwx 1 root www-data 30 Dec  1 02:22 /tmp/systemd-private-da6f7cfc1d2f4e26b9b439c2ae559f72-lshttpd.service-JKyVjn/tmp/lshttpd/.rtreport -> /dev/shm/lsws/status/.rtreport
```